### PR TITLE
Update the link of the GitHub Actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![CI Status](https://github.com/se-edu/addressbook-level3/workflows/Java%20CI/badge.svg)](https://github.com/se-edu/addressbook-level3/actions)
+[![CI Status](https://github.com//AY2425S2-CS2103T-T16-3/tp/actions/workflows/gradle.yml/badge.svg)](https://github.com/AY2425S2-CS2103T-T16-3/tp/actions)
 [![codecov](https://codecov.io/gh/AY2425S2-CS2103T-T16-3/tp/graph/badge.svg?token=AL9NMUSTGX)](https://codecov.io/gh/AY2425S2-CS2103T-T16-3/tp)
 
 ![Ui](docs/images/Ui.png)


### PR DESCRIPTION
A2. Update the link of the GitHub Actions build status badge (Build Status) so that it reflects the build status of your team repo.