### PR TITLE
Add ```viewstats``` command

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -470,6 +470,10 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 1. User requests to view statistics of applications to a specific job
 2. QuickHire shows the list of jobs and their corresponding number of applications
 
+**Extensions**
+
+* 2a. The stats list is empty (i.e., no one applied for a job)
+    *2a1. Notify user about empty list
 ---
 
 

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -339,6 +339,7 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 | `* *`    | user     | edit an applicant's contact                         | rectify any discrepancies in the applicant's contact details                   |
 | `* *`    | new user | import my list of applicant's contact               | seamlessly migrate data from using one device to this another                  |
 | `* *`    | user     | add remarks to an applicant's contact details       | note down interesting details about a candidate                                |
+| `* *`    | user     | view statistics of applications to a specific role  | make informed decisions on recruiting priorities                               |
 | `*`      | new user | play around with sample data                        | gain more familiarity with using the application                               |
 
 ### Use Cases
@@ -462,6 +463,12 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
     * 2a1. Notify user about the empty list.
 
   Use case ends.
+
+**Use Case: UC08 - Viewing statistics of applications to a specific job**
+
+**MSS**
+1. User requests to view statistics of applications to a specific job
+2. QuickHire shows the list of jobs and their corresponding number of applications
 
 ---
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -170,6 +170,12 @@ Examples:
 *  `remark 1 r/Likes to code` Adds a remark (`Likes to code`) to the 1st person
 *  `remark 1 r/` Clears all remarks for the 1st person
 
+### Viewing job application statistics: 'viewstats'
+
+Displays the amount of applications for each role.
+
+Format: `viewstats`
+
 ### Exiting the program : `exit`
 
 Exits the program.
@@ -242,5 +248,6 @@ Action | Format, Examples
 **Edit** | `edit INDEX [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [j/JOB TITLE] [l/LABEL] [s/INTERVIEW_SCHEDULE] [r/REMARK] [t/TAG]…​`<br> e.g.,`edit 2 n/James Lee e/jameslee@example.com`
 **Find** | `find KEYWORD [MORE_KEYWORDS]`<br> e.g., `find James Jake`
 **Remark** | `remark INDEX r/REMARK`
+**ViewStats** | `viewstats`
 **List** | `list`
 **Help** | `help`

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -172,7 +172,7 @@ Examples:
 
 ### Viewing job application statistics: 'viewstats'
 
-Displays the amount of applications for each role.
+Displays the number of applications for each role.
 
 Format: `viewstats`
 

--- a/src/main/java/seedu/address/logic/commands/ViewStatsCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ViewStatsCommand.java
@@ -1,0 +1,25 @@
+package seedu.address.logic.commands;
+
+import java.util.Map;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.person.JobTitle;
+import seedu.address.model.Model;
+
+public class ViewStatsCommand extends Command {
+
+    public static final String COMMAND_WORD = "viewstats";
+    public static final String MESSAGE_SUCCESS = "Statistics:\n%s";
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        Map<JobTitle, Long> stats = model.getAddressBook().getJobApplicantStatistics();
+        StringBuilder sb = new StringBuilder();
+        for (Map.Entry<JobTitle, Long> entry : stats.entrySet()) {
+            sb.append(entry.getKey().toString())
+                    .append(": ")
+                    .append(entry.getValue())
+                    .append("\n");
+        }
+        return new CommandResult(String.format(MESSAGE_SUCCESS, sb.toString()));
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/ViewStatsCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ViewStatsCommand.java
@@ -20,11 +20,15 @@ public class ViewStatsCommand extends Command {
     public CommandResult execute(Model model) throws CommandException {
         Map<JobTitle, Long> stats = model.getAddressBook().getJobApplicantStatistics();
         StringBuilder sb = new StringBuilder();
-        for (Map.Entry<JobTitle, Long> entry : stats.entrySet()) {
-            sb.append(entry.getKey().toString())
-                    .append(": ")
-                    .append(entry.getValue())
-                    .append("\n");
+        if (stats.isEmpty()) {
+            sb.append("(No existing applications at the moment)");
+        } else {
+            for (Map.Entry<JobTitle, Long> entry : stats.entrySet()) {
+                sb.append(entry.getKey().toString())
+                        .append(": ")
+                        .append(entry.getValue())
+                        .append("\n");
+            }
         }
         return new CommandResult(String.format(MESSAGE_SUCCESS, sb.toString()));
     }

--- a/src/main/java/seedu/address/logic/commands/ViewStatsCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ViewStatsCommand.java
@@ -1,10 +1,16 @@
 package seedu.address.logic.commands;
 
 import java.util.Map;
-import seedu.address.logic.commands.exceptions.CommandException;
-import seedu.address.model.person.JobTitle;
-import seedu.address.model.Model;
 
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.person.JobTitle;
+
+/**
+ * Returns number of job applications grouped by their job title.
+ * This command aggregates the number of applicants by their job titles
+ * and displays the results in a formatted string.
+ */
 public class ViewStatsCommand extends Command {
 
     public static final String COMMAND_WORD = "viewstats";

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -18,6 +18,7 @@ import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.RemarkCommand;
+import seedu.address.logic.commands.ViewStatsCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
@@ -80,6 +81,8 @@ public class AddressBookParser {
 
         case RemarkCommand.COMMAND_WORD:
             return new RemarkCommandParser().parse(arguments);
+        case ViewStatsCommand.COMMAND_WORD:
+            return new ViewStatsCommand();
 
         default:
             logger.finer("This user input caused a ParseException: " + userInput);

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -3,9 +3,12 @@ package seedu.address.model;
 import static java.util.Objects.requireNonNull;
 
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import javafx.collections.ObservableList;
 import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.model.person.JobTitle;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.UniquePersonList;
 
@@ -92,6 +95,14 @@ public class AddressBook implements ReadOnlyAddressBook {
      */
     public void removePerson(Person key) {
         persons.remove(key);
+    }
+
+    /**
+     * Returns a mapping of each job title to applicants.
+     */
+    public Map<JobTitle, Long> getJobApplicantStatistics() {
+        return getPersonList().stream()
+                .collect(Collectors.groupingBy(Person::getJobTitle, Collectors.counting()));
     }
 
     //// util methods

--- a/src/main/java/seedu/address/model/ReadOnlyAddressBook.java
+++ b/src/main/java/seedu/address/model/ReadOnlyAddressBook.java
@@ -1,10 +1,10 @@
 package seedu.address.model;
 
+import java.util.Map;
+
 import javafx.collections.ObservableList;
 import seedu.address.model.person.JobTitle;
 import seedu.address.model.person.Person;
-
-import java.util.Map;
 
 /**
  * Unmodifiable view of an address book

--- a/src/main/java/seedu/address/model/ReadOnlyAddressBook.java
+++ b/src/main/java/seedu/address/model/ReadOnlyAddressBook.java
@@ -1,7 +1,10 @@
 package seedu.address.model;
 
 import javafx.collections.ObservableList;
+import seedu.address.model.person.JobTitle;
 import seedu.address.model.person.Person;
+
+import java.util.Map;
 
 /**
  * Unmodifiable view of an address book
@@ -14,4 +17,5 @@ public interface ReadOnlyAddressBook {
      */
     ObservableList<Person> getPersonList();
 
+    Map<JobTitle, Long> getJobApplicantStatistics();
 }

--- a/src/test/java/seedu/address/logic/commands/ViewStatsCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ViewStatsCommandTest.java
@@ -1,0 +1,56 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.person.Person;
+import seedu.address.testutil.PersonBuilder;
+
+public class ViewStatsCommandTest {
+
+    @Test
+    public void execute_noPersons_emptyStatsMessage() throws CommandException {
+        Model model = new ModelManager();
+        ViewStatsCommand command = new ViewStatsCommand();
+        CommandResult result = command.execute(model);
+        String expectedMessage = "Statistics:\n";
+        assertEquals(expectedMessage, result.getFeedbackToUser());
+    }
+
+    @Test
+    public void execute_somePersons_showsCorrectStats() throws CommandException {
+        Model model = new ModelManager();
+
+        Person softwareEngineer = new PersonBuilder()
+                .withName("Alice")
+                .withJobTitle("Software Engineer")
+                .build();
+        Person dataScientist = new PersonBuilder()
+                .withName("Bob")
+                .withJobTitle("Data Scientist")
+                .build();
+        Person uiDesigner = new PersonBuilder()
+                .withName("Charlie")
+                .withJobTitle("UI Designer")
+                .build();
+
+        model.addPerson(softwareEngineer);
+        model.addPerson(dataScientist);
+        model.addPerson(uiDesigner);
+
+        ViewStatsCommand command = new ViewStatsCommand();
+        CommandResult result = command.execute(model);
+
+        String expectedMessage = "Statistics:\n"
+                + "Data Scientist: 1\n"
+                + "Software Engineer: 1\n"
+                + "UI Designer: 1\n";
+
+        assertEquals(expectedMessage, result.getFeedbackToUser());
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/ViewStatsCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ViewStatsCommandTest.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
 
-import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;

--- a/src/test/java/seedu/address/logic/commands/ViewStatsCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ViewStatsCommandTest.java
@@ -17,7 +17,7 @@ public class ViewStatsCommandTest {
         Model model = new ModelManager();
         ViewStatsCommand command = new ViewStatsCommand();
         CommandResult result = command.execute(model);
-        String expectedMessage = "Statistics:\n";
+        String expectedMessage = "Statistics:\n(No existing applications at the moment)";
         assertEquals(expectedMessage, result.getFeedbackToUser());
     }
 

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -25,6 +25,7 @@ import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.RemarkCommand;
+import seedu.address.logic.commands.ViewStatsCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.PersonDetailsContainKeywordsPredicate;
@@ -108,4 +109,11 @@ public class AddressBookParserTest {
                 + " " + INDEX_FIRST_PERSON.getOneBased() + " " + PREFIX_REMARK + VALID_REMARK_LEETCODE)
                 instanceof RemarkCommand);
     }
+
+    @Test
+    public void parseCommand_viewstats() throws Exception {
+        assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD) instanceof ViewStatsCommand);
+        assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD + " 3") instanceof ViewStatsCommand);
+    }
+
 }

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -112,8 +112,8 @@ public class AddressBookParserTest {
 
     @Test
     public void parseCommand_viewstats() throws Exception {
-        assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD) instanceof ViewStatsCommand);
-        assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD + " 3") instanceof ViewStatsCommand);
+        assertTrue(parser.parseCommand(ViewStatsCommand.COMMAND_WORD) instanceof ViewStatsCommand);
+        assertTrue(parser.parseCommand(ViewStatsCommand.COMMAND_WORD + " 3") instanceof ViewStatsCommand);
     }
 
 }

--- a/src/test/java/seedu/address/model/AddressBookTest.java
+++ b/src/test/java/seedu/address/model/AddressBookTest.java
@@ -13,11 +13,13 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
+import seedu.address.model.person.JobTitle;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.exceptions.DuplicatePersonException;
 import seedu.address.testutil.PersonBuilder;
@@ -102,6 +104,11 @@ public class AddressBookTest {
         @Override
         public ObservableList<Person> getPersonList() {
             return persons;
+        }
+
+        @Override
+        public Map<JobTitle, Long> getJobApplicantStatistics() {
+            return Map.of();
         }
     }
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/3f360296-f685-4a7d-9426-37171af74b30)

The ```viewstats``` command allows users to view the number of applications for each job title.

### Main changes
- Add new ```getJobApplicantStatistics()``` method in AddressBook.java
- Update ```AddressBookParser``` for new ```viewstats``` feature

### Testing
- Implemented unit tests to verify:
    + No persons in the address book
    + Persons with specified job titles (e.g., "Software Engineer", "Data Scientist", "UI Designer")