### PR TITLE
Highlight error messages

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -77,17 +77,16 @@ Format: `help`
 
 Adds a person to the address book.
 
-Format: `add n/NAME p/PHONE_NUMBER e/EMAIL a/ADDRESS j/JOB TITLE l/LABEL s/INTERVIEW_SCHEDULE r/REMARK [t/TAG]…​`
+Format: `add n/NAME p/PHONE_NUMBER e/EMAIL a/ADDRESS j/JOB TITLE l/LABEL [s/INTERVIEW_SCHEDULE] [r/REMARK] [t/TAG]…​`
 
 <div markdown="span" class="alert alert-primary">:bulb: **Tip:**
 A label can only be Unreviewed, Shortlisted, Rejected or Accepted.</br>
 A person can have any number of tags (including 0)
-You may choose to leave Interview Schedule and Remark as empty
 </div>
 
 Examples:
 * `add n/John Doe p/98765432 e/johnd@example.com a/311, Clementi Ave 2, #02-25 s/ j/Data Scientist l/Unreviewed r/Likes to code t/friends t/owesMoney`
-* `add n/Vish p/1293123 e/sample@domain.com a/213123 street j/ProData guy s/ l/Rejected r/`
+* `add n/Vish p/1293123 e/sample@domain.com a/213123 street j/ProData guy l/Rejected`
 
 ### Listing all persons : `list`
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -77,16 +77,17 @@ Format: `help`
 
 Adds a person to the address book.
 
-Format: `add n/NAME p/PHONE_NUMBER e/EMAIL a/ADDRESS j/JOB TITLE l/LABEL [s/INTERVIEW_SCHEDULE] [r/REMARK] [t/TAG]…​`
+Format: `add n/NAME p/PHONE_NUMBER e/EMAIL a/ADDRESS j/JOB TITLE l/LABEL s/INTERVIEW_SCHEDULE r/REMARK [t/TAG]…​`
 
 <div markdown="span" class="alert alert-primary">:bulb: **Tip:**
 A label can only be Unreviewed, Shortlisted, Rejected or Accepted.
 A person can have any number of tags (including 0)
+You may choose to leave Interview Schedule and Remark as empty
 </div>
 
 Examples:
-* `add n/John Doe p/98765432 e/johnd@example.com a/John street, block 123, #01-01 s/10-02-2025 10:00 r/Likes to code l/Unreviewed`
-* `add n/Betsy Crowe t/friend e/betsycrowe@example.com a/Newgate Prison p/1234567 l/Unreviewed t/criminal`
+* `add n/John Doe p/98765432 e/johnd@example.com a/311, Clementi Ave 2, #02-25 s/ j/Data Scientist l/Unreviewed r/Likes to code t/friends t/owesMoney`
+* `add n/Vish p/1293123 e/sample@domain.com a/213123 street j/ProData guy s/ l/Rejected r/`
 
 ### Listing all persons : `list`
 

--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -36,9 +36,10 @@ public class Messages {
 
     public static String getErrorMessageForMissingPrefixes(Prefix... missingPrefixes) {
         assert missingPrefixes.length > 0;
+        
         Set<String> missingFields =
                 Stream.of(missingPrefixes).map(Prefix::getPrefixField).collect(Collectors.toSet());
-        
+
         return MESSAGE_MISSING_FIELDS + String.join(", ", missingFields);
     }
 

--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -36,10 +36,8 @@ public class Messages {
 
     public static String getErrorMessageForMissingPrefixes(Prefix... missingPrefixes) {
         assert missingPrefixes.length > 0;
-        
         Set<String> missingFields =
                 Stream.of(missingPrefixes).map(Prefix::getPrefixField).collect(Collectors.toSet());
-
         return MESSAGE_MISSING_FIELDS + String.join(", ", missingFields);
     }
 

--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -19,6 +19,9 @@ public class Messages {
     public static final String MESSAGE_DUPLICATE_FIELDS =
             "Multiple values specified for the following single-valued field(s): ";
 
+    public static final String MESSAGE_MISSING_FIELDS =
+            "Missing the following values: ";
+
     /**
      * Returns an error message indicating the duplicate prefixes.
      */
@@ -29,6 +32,16 @@ public class Messages {
                 Stream.of(duplicatePrefixes).map(Prefix::toString).collect(Collectors.toSet());
 
         return MESSAGE_DUPLICATE_FIELDS + String.join(" ", duplicateFields);
+    }
+
+
+    public static String getErrorMessageForMissingPrefixes(Prefix... missingPrefixes) {
+        assert missingPrefixes.length > 0;
+        Set<String> missingFields =
+                Stream.of(missingPrefixes).map(Prefix::getPrefixField).collect(Collectors.toSet());
+
+
+        return MESSAGE_MISSING_FIELDS + String.join(", ", missingFields);
     }
 
     /**

--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -34,13 +34,11 @@ public class Messages {
         return MESSAGE_DUPLICATE_FIELDS + String.join(" ", duplicateFields);
     }
 
-
     public static String getErrorMessageForMissingPrefixes(Prefix... missingPrefixes) {
         assert missingPrefixes.length > 0;
         Set<String> missingFields =
                 Stream.of(missingPrefixes).map(Prefix::getPrefixField).collect(Collectors.toSet());
-
-
+        
         return MESSAGE_MISSING_FIELDS + String.join(", ", missingFields);
     }
 

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -51,11 +51,15 @@ public class AddCommandParser implements Parser<AddCommand> {
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS,
                         PREFIX_JOBTITLE, PREFIX_SCHEDULE, PREFIX_LABEL, PREFIX_REMARK, PREFIX_TAG);
 
-        if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_ADDRESS, PREFIX_PHONE,
-                PREFIX_JOBTITLE, PREFIX_LABEL, PREFIX_EMAIL)
-                || !argMultimap.getPreamble().isEmpty()) {
+        //!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_ADDRESS, PREFIX_PHONE,
+        //                PREFIX_JOBTITLE, PREFIX_LABEL, PREFIX_EMAIL)
+        //                ||
+
+        if (!argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
         }
+        argMultimap.verifyNoMissingPrefixes(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS,
+                PREFIX_JOBTITLE, PREFIX_LABEL);
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS,
                 PREFIX_JOBTITLE, PREFIX_SCHEDULE, PREFIX_LABEL, PREFIX_REMARK);
 

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -55,11 +55,13 @@ public class AddCommandParser implements Parser<AddCommand> {
         //                PREFIX_JOBTITLE, PREFIX_LABEL, PREFIX_EMAIL)
         //                ||
 
+
+        argMultimap.verifyNoMissingPrefixes(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS,
+                PREFIX_JOBTITLE, PREFIX_LABEL);
+
         if (!argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
         }
-        argMultimap.verifyNoMissingPrefixes(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS,
-                PREFIX_JOBTITLE, PREFIX_LABEL);
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS,
                 PREFIX_JOBTITLE, PREFIX_SCHEDULE, PREFIX_LABEL, PREFIX_REMARK);
 

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -51,11 +51,6 @@ public class AddCommandParser implements Parser<AddCommand> {
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS,
                         PREFIX_JOBTITLE, PREFIX_SCHEDULE, PREFIX_LABEL, PREFIX_REMARK, PREFIX_TAG);
 
-        //!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_ADDRESS, PREFIX_PHONE,
-        //                PREFIX_JOBTITLE, PREFIX_LABEL, PREFIX_EMAIL)
-        //                ||
-
-
         argMultimap.verifyNoMissingPrefixes(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS,
                 PREFIX_JOBTITLE, PREFIX_LABEL);
 

--- a/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
@@ -59,7 +59,7 @@ public class ArgumentMultimap {
      * Returns the preamble (text before the first valid prefix). Trims any leading/trailing spaces.
      */
     public String getPreamble() {
-        return getValue(new Prefix("")).orElse("");
+        return getValue(new Prefix("", "")).orElse("");
     }
 
     /**
@@ -74,5 +74,17 @@ public class ArgumentMultimap {
         if (duplicatedPrefixes.length > 0) {
             throw new ParseException(Messages.getErrorMessageForDuplicatePrefixes(duplicatedPrefixes));
         }
+    }
+
+    public void verifyNoMissingPrefixes(Prefix... prefixes) throws ParseException {
+
+        Prefix[] missingPrefixes = Stream.of(prefixes).distinct()
+                .filter(prefix -> !argMultimap.containsKey(prefix)) // Check if prefix is missing
+                .toArray(Prefix[]::new);
+
+        if (missingPrefixes.length > 0) {
+            throw new ParseException(Messages.getErrorMessageForMissingPrefixes(missingPrefixes));
+        }
+
     }
 }

--- a/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
@@ -76,6 +76,10 @@ public class ArgumentMultimap {
         }
     }
 
+    /**
+     * Throws a {@code ParseException} if any of the prefixes given in {@code prefixes} is missing
+     * among the arguments
+     */
     public void verifyNoMissingPrefixes(Prefix... prefixes) throws ParseException {
 
         Prefix[] missingPrefixes = Stream.of(prefixes).distinct()

--- a/src/main/java/seedu/address/logic/parser/ArgumentTokenizer.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentTokenizer.java
@@ -90,11 +90,11 @@ public class ArgumentTokenizer {
         prefixPositions.sort((prefix1, prefix2) -> prefix1.getStartPosition() - prefix2.getStartPosition());
 
         // Insert a PrefixPosition to represent the preamble
-        PrefixPosition preambleMarker = new PrefixPosition(new Prefix(""), 0);
+        PrefixPosition preambleMarker = new PrefixPosition(new Prefix("", ""), 0);
         prefixPositions.add(0, preambleMarker);
 
         // Add a dummy PrefixPosition to represent the end of the string
-        PrefixPosition endPositionMarker = new PrefixPosition(new Prefix(""), argsString.length());
+        PrefixPosition endPositionMarker = new PrefixPosition(new Prefix("", ""), argsString.length());
         prefixPositions.add(endPositionMarker);
 
         // Map prefixes to their argument values (if any)

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -6,14 +6,14 @@ package seedu.address.logic.parser;
 public class CliSyntax {
 
     /* Prefix definitions */
-    public static final Prefix PREFIX_NAME = new Prefix("n/");
-    public static final Prefix PREFIX_PHONE = new Prefix("p/");
-    public static final Prefix PREFIX_EMAIL = new Prefix("e/");
-    public static final Prefix PREFIX_ADDRESS = new Prefix("a/");
-    public static final Prefix PREFIX_TAG = new Prefix("t/");
-    public static final Prefix PREFIX_LABEL = new Prefix("l/");
-    public static final Prefix PREFIX_SCHEDULE = new Prefix("s/");
-    public static final Prefix PREFIX_JOBTITLE = new Prefix("j/");
-    public static final Prefix PREFIX_REMARK = new Prefix("r/");
+    public static final Prefix PREFIX_NAME = new Prefix("n/", "Name");
+    public static final Prefix PREFIX_PHONE = new Prefix("p/", "Phone");
+    public static final Prefix PREFIX_EMAIL = new Prefix("e/", "Email");
+    public static final Prefix PREFIX_ADDRESS = new Prefix("a/", "Address");
+    public static final Prefix PREFIX_TAG = new Prefix("t/", "Tag");
+    public static final Prefix PREFIX_LABEL = new Prefix("l/", "Label");
+    public static final Prefix PREFIX_SCHEDULE = new Prefix("s/", "Schedule");
+    public static final Prefix PREFIX_JOBTITLE = new Prefix("j/", "Jobtitle");
+    public static final Prefix PREFIX_REMARK = new Prefix("r/", "Remark");
 
 }

--- a/src/main/java/seedu/address/logic/parser/Prefix.java
+++ b/src/main/java/seedu/address/logic/parser/Prefix.java
@@ -9,6 +9,13 @@ public class Prefix {
 
     private final String prefixField;
 
+    /**
+     * Constructs a prefix using {@code prefix} to indicate the prefix and
+     * {@code prefixField} to indicate what the prefix refers to.
+     *
+     * @param prefix
+     * @param prefixField
+     */
     public Prefix(String prefix, String prefixField) {
         this.prefix = prefix;
         this.prefixField = prefixField;

--- a/src/main/java/seedu/address/logic/parser/Prefix.java
+++ b/src/main/java/seedu/address/logic/parser/Prefix.java
@@ -7,12 +7,19 @@ package seedu.address.logic.parser;
 public class Prefix {
     private final String prefix;
 
-    public Prefix(String prefix) {
+    private final String prefixField;
+
+    public Prefix(String prefix, String prefixField) {
         this.prefix = prefix;
+        this.prefixField = prefixField;
     }
 
     public String getPrefix() {
         return prefix;
+    }
+
+    public String getPrefixField() {
+        return prefixField;
     }
 
     @Override
@@ -37,6 +44,7 @@ public class Prefix {
         }
 
         Prefix otherPrefix = (Prefix) other;
-        return prefix.equals(otherPrefix.prefix);
+        return prefix.equals(otherPrefix.prefix)
+                && prefixField.equals(otherPrefix.prefixField);
     }
 }

--- a/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
@@ -233,32 +233,43 @@ public class AddCommandParserTest {
 
     @Test
     public void parse_compulsoryFieldMissing_failure() {
-        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE);
+        String expectedMessage = String.format(Messages.getErrorMessageForMissingPrefixes(PREFIX_NAME));
 
         // missing name prefix
-
         assertParseFailure(parser, VALID_NAME_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
                         + JOBTITLE_DESC_BOB + SCHEDULE_DESC_BOB + LABEL_DESC_BOB + REMARK_DESC_BOB,
                 expectedMessage);
+
+        expectedMessage = String.format(Messages.getErrorMessageForMissingPrefixes(PREFIX_PHONE));
 
         // missing phone prefix
         assertParseFailure(parser, NAME_DESC_BOB + VALID_PHONE_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
                         + JOBTITLE_DESC_BOB + SCHEDULE_DESC_BOB + LABEL_DESC_BOB + REMARK_DESC_BOB,
                 expectedMessage);
 
+        expectedMessage = String.format(Messages.getErrorMessageForMissingPrefixes(PREFIX_EMAIL));
+
         // missing email prefix
         assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + VALID_EMAIL_BOB + ADDRESS_DESC_BOB
                         + JOBTITLE_DESC_BOB + SCHEDULE_DESC_BOB + LABEL_DESC_BOB + REMARK_DESC_BOB,
                 expectedMessage);
+
+        expectedMessage = String.format(Messages.getErrorMessageForMissingPrefixes(PREFIX_ADDRESS));
 
         // missing address prefix
         assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + VALID_ADDRESS_BOB
                         + JOBTITLE_DESC_BOB + SCHEDULE_DESC_BOB + LABEL_DESC_BOB + REMARK_DESC_BOB,
                 expectedMessage);
 
+        expectedMessage = String.format(Messages.getErrorMessageForMissingPrefixes(PREFIX_LABEL));
+
         // missing label prefix
         assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
                 + JOBTITLE_DESC_BOB + SCHEDULE_DESC_BOB + VALID_LABEL_BOB, expectedMessage);
+
+        expectedMessage = String.format(Messages.getErrorMessageForMissingPrefixes(PREFIX_NAME,
+                PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS,
+                PREFIX_JOBTITLE, PREFIX_LABEL));
 
         // all prefixes missing
         assertParseFailure(parser, VALID_NAME_BOB + VALID_PHONE_BOB + VALID_EMAIL_BOB + VALID_ADDRESS_BOB

--- a/src/test/java/seedu/address/logic/parser/ArgumentTokenizerTest.java
+++ b/src/test/java/seedu/address/logic/parser/ArgumentTokenizerTest.java
@@ -9,10 +9,10 @@ import org.junit.jupiter.api.Test;
 
 public class ArgumentTokenizerTest {
 
-    private final Prefix unknownPrefix = new Prefix("--u");
-    private final Prefix pSlash = new Prefix("p/");
-    private final Prefix dashT = new Prefix("-t");
-    private final Prefix hatQ = new Prefix("^Q");
+    private final Prefix unknownPrefix = new Prefix("--u", "username");
+    private final Prefix pSlash = new Prefix("p/", "phone?");
+    private final Prefix dashT = new Prefix("-t", "tag?");
+    private final Prefix hatQ = new Prefix("^Q", "question");
 
     @Test
     public void tokenize_emptyArgsString_noValues() {
@@ -138,13 +138,13 @@ public class ArgumentTokenizerTest {
 
     @Test
     public void equalsMethod() {
-        Prefix aaa = new Prefix("aaa");
+        Prefix aaa = new Prefix("aaa", "aaa");
 
         assertEquals(aaa, aaa);
-        assertEquals(aaa, new Prefix("aaa"));
+        assertEquals(aaa, new Prefix("aaa", "aaa"));
 
         assertNotEquals(aaa, "aaa");
-        assertNotEquals(aaa, new Prefix("aab"));
+        assertNotEquals(aaa, new Prefix("aab", "aab"));
     }
 
 }


### PR DESCRIPTION
fixes #97 
Added error message highlighting
Edited the prefix class to also have an attached field, so that we know what each prefix indicates. 
If the fieldname doesn't really matter you can just fill it in as "". Other functionalites of prefix have no change, only updating the equals method to match
