### PR TITLE
Fix PE-D bugs for schedule commands

### DIFF
--- a/src/main/java/seedu/address/commons/util/ScheduleUtil.java
+++ b/src/main/java/seedu/address/commons/util/ScheduleUtil.java
@@ -1,17 +1,33 @@
 package seedu.address.commons.util;
 
+import java.time.Duration;
 import java.time.LocalTime;
 
 /**
  * ScheduleUtil contains methods for manipulating Schedules.
  */
 public class ScheduleUtil {
+    private static final long MIN_DURATION_MINUTES = 15;
+    private static final long MAX_DURATION_MINUTES = 4 * 60;
 
     /**
-     * Check that {@code startTime} provided is earlier than {@code endTime} provided
+     * Checks that {@code startTime} provided is earlier than {@code endTime} provided
      * @return true if startTime is before endTime
      */
     public static boolean checkStartEndDateTime(LocalTime startTime, LocalTime endTime) {
         return startTime.isBefore(endTime);
+    }
+
+    /**
+     * Validates that the duration between them is at least 15 minutes, and the duration does not exceed 4 hours.
+     *
+     * @param startTime the start time
+     * @param endTime the end time
+     * @return true if all constraints are satisfied, false otherwise
+     */
+    public static boolean isValidDuration(LocalTime startTime, LocalTime endTime) {
+        long durationMinutes = Duration.between(startTime, endTime).toMinutes();
+        return durationMinutes >= MIN_DURATION_MINUTES
+                && durationMinutes <= MAX_DURATION_MINUTES;
     }
 }

--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -22,7 +22,12 @@ public class Messages {
     public static final String MESSAGE_FILE_EXISTS = "File at '%1$s' already exists!";
     public static final String MESSAGE_SCHEDULE_START_TIME_BEFORE_END_TIME =
             "The end time of the interview schedule should be strictly later than "
-                    + "start time of the interview schedule.";
+                    + "start time of the interview schedule. \n"
+                    + "End time of interview schedule must be at least 15 minutes after start time and "
+                    + "no more than 4 hours later";;
+    public static final String MESSAGE_SCHEDULE_INVALID_DURATION =
+            "End time of interview schedule must be at least 15 minutes after start time and "
+                    + "no more than 4 hours later";
     public static final String MESSAGE_SCHEDULE_TIMING_CLASH =
             "This interview schedule's timing conflicts with an existing interview schedule. \n"
                     + "The schedule board supports only non-overlapping intervals. \n"

--- a/src/main/java/seedu/address/logic/commands/schedule/AddScheduleCommand.java
+++ b/src/main/java/seedu/address/logic/commands/schedule/AddScheduleCommand.java
@@ -30,9 +30,9 @@ public class AddScheduleCommand extends Command {
 
     public static final String COMMAND_WORD = "sadd";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds an interview schedule to board. "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds an interview schedule to board. \n"
             + "Parameters: "
-            + PREFIX_CANDIDATE + "CANDIDATE_INDEX (must be a positive integer) "
+            + PREFIX_CANDIDATE + "INDEX (must be a positive integer) "
             + PREFIX_SCHEDULE + "SCHEDULE_DATE_AND_DURATION "
             + PREFIX_MODE + "MODE\n"
             + "Example: " + COMMAND_WORD + " "

--- a/src/main/java/seedu/address/logic/commands/schedule/DeleteScheduleCommand.java
+++ b/src/main/java/seedu/address/logic/commands/schedule/DeleteScheduleCommand.java
@@ -22,7 +22,7 @@ public class DeleteScheduleCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Deletes the interview schedule identified by the index number used in the displayed schedule board.\n"
-            + "Parameters: " + "INDEX (must be a positive integer)\n"
+            + "Parameters: " + "SCHEDULE_INDEX (must be a positive integer)\n"
             + "Example: " + COMMAND_WORD + " 2";
 
     public static final String MESSAGE_DELETE_SCHEDULE_SUCCESS = "Deleted schedule: %1$s";

--- a/src/main/java/seedu/address/logic/commands/schedule/EditScheduleCommand.java
+++ b/src/main/java/seedu/address/logic/commands/schedule/EditScheduleCommand.java
@@ -38,7 +38,7 @@ public class EditScheduleCommand extends Command {
             + "schedule identified "
             + "by the index number used in the displayed schedule list. "
             + "Existing values will be overwritten by the input values.\n"
-            + "Parameters: INDEX (must be a positive integer) "
+            + "Parameters: SCHEDULE_INDEX (must be a positive integer) "
             + "[" + PREFIX_SCHEDULE + "SCHEDULE_DATE_AND_DURATION" + "] "
             + "[" + PREFIX_MODE + "MODE" + "]\n"
             + "Example: " + COMMAND_WORD + " 1 "

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -2,6 +2,8 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.ScheduleUtil.checkStartEndDateTime;
+import static seedu.address.commons.util.ScheduleUtil.isValidDuration;
+import static seedu.address.logic.Messages.MESSAGE_SCHEDULE_INVALID_DURATION;
 import static seedu.address.logic.Messages.MESSAGE_SCHEDULE_START_TIME_BEFORE_END_TIME;
 
 import java.nio.file.Path;
@@ -44,7 +46,8 @@ public class ParserUtil {
     public static final String MESSAGE_INVALID_TIME =
             "Invalid time or incorrect format of time. Format of interview duration's start and end time should be "
                     + "HH:mm HH:mm (e.g. 12:00 13:00)\n"
-                    + "End time should be strictly larger than start time";
+                    + "End time of interview schedule must be at least 15 minutes after start time and "
+                    + "no more than 4 hours later";
 
     /**
      * Parses {@code oneBasedIndex} into an {@code Index} and returns it. Leading and trailing whitespaces will be
@@ -188,6 +191,10 @@ public class ParserUtil {
 
         if (!checkStartEndDateTime(startTime, endTime)) {
             throw new ParseException(MESSAGE_SCHEDULE_START_TIME_BEFORE_END_TIME);
+        }
+
+        if (!isValidDuration(startTime, endTime)) {
+            throw new ParseException(MESSAGE_SCHEDULE_INVALID_DURATION);
         }
 
         ArrayList<LocalTime> starEndTimeList = new ArrayList<>();

--- a/src/main/java/seedu/address/logic/parser/schedule/AddScheduleCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/schedule/AddScheduleCommandParser.java
@@ -41,6 +41,9 @@ public class AddScheduleCommandParser implements Parser<AddScheduleCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public AddScheduleCommand parse(String args) throws ParseException {
+        if (args.isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddScheduleCommand.MESSAGE_USAGE));
+        }
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_CANDIDATE, PREFIX_SCHEDULE, PREFIX_MODE);
 

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -123,6 +123,11 @@ public class CommandTestUtil {
 
     public static final String INVALID_SCHEDULE_END_TIME_DESC = " " + PREFIX_SCHEDULE + VALID_DATE + " "
             + VALID_START_TIME + " " + INVALID_END_TIME;
+
+    public static final String INVALID_SCHEDULE_DURATION_DESC = " " + PREFIX_SCHEDULE + VALID_DATE + " "
+            + "13:00 13:01";
+    public static final String INVALID_SCHEDULE_DURATION_DESC_2 = " " + PREFIX_SCHEDULE + VALID_DATE + " "
+            + "13:00 17:01";
     public static final String INVALID_MODE_DESC = " " + PREFIX_MODE + INVALID_MODE;
     public static final String INVALID_CANDIDATE_INDEX_DESC = PREFIX_CANDIDATE + "-2";
 

--- a/src/test/java/seedu/address/logic/parser/schedule/AddScheduleCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/schedule/AddScheduleCommandParserTest.java
@@ -2,9 +2,12 @@ package seedu.address.logic.parser.schedule;
 
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.Messages.MESSAGE_SCHEDULE_INVALID_DURATION;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_CANDIDATE_INDEX_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_MODE_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_SCHEDULE_DATE_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_SCHEDULE_DURATION_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_SCHEDULE_DURATION_DESC_2;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_SCHEDULE_END_TIME_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_SCHEDULE_START_TIME_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_NON_EMPTY;
@@ -94,9 +97,17 @@ public class AddScheduleCommandParserTest {
         assertParseFailure(parser, VALID_CANDIDATE_INDEX_DESC + INVALID_SCHEDULE_START_TIME_DESC
                         + VALID_MODE_DESC, MESSAGE_INVALID_TIME);
 
-        // invalid startTime
+        // invalid endTime
         assertParseFailure(parser, VALID_CANDIDATE_INDEX_DESC + INVALID_SCHEDULE_END_TIME_DESC
                         + VALID_MODE_DESC, MESSAGE_INVALID_TIME);
+
+        // invalid duration
+        assertParseFailure(parser, VALID_CANDIDATE_INDEX_DESC + INVALID_SCHEDULE_DURATION_DESC
+                + VALID_MODE_DESC, MESSAGE_SCHEDULE_INVALID_DURATION);
+
+        // invalid duration
+        assertParseFailure(parser, VALID_CANDIDATE_INDEX_DESC + INVALID_SCHEDULE_DURATION_DESC_2
+                + VALID_MODE_DESC, MESSAGE_SCHEDULE_INVALID_DURATION);
 
         // invalid mode
         assertParseFailure(parser, VALID_CANDIDATE_INDEX_DESC + VALID_SCHEDULE_DESC
@@ -112,5 +123,11 @@ public class AddScheduleCommandParserTest {
         assertParseFailure(parser, PREAMBLE_NON_EMPTY + VALID_CANDIDATE_INDEX_DESC + VALID_SCHEDULE_DESC
                         + VALID_MODE_DESC,
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddScheduleCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_noArgs_throwsParseException() {
+        assertParseFailure(parser, "", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                AddScheduleCommand.MESSAGE_USAGE));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/schedule/EditScheduleCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/schedule/EditScheduleCommandParserTest.java
@@ -2,8 +2,11 @@ package seedu.address.logic.parser.schedule;
 
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.Messages.MESSAGE_SCHEDULE_INVALID_DURATION;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_MODE_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_SCHEDULE_DATE_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_SCHEDULE_DURATION_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_SCHEDULE_DURATION_DESC_2;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_SCHEDULE_END_TIME_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_SCHEDULE_START_TIME_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.SCHEDULE_DESC_AMY;
@@ -71,9 +74,16 @@ public class EditScheduleCommandParserTest {
                 MESSAGE_INVALID_TIME); // invalid start time
         assertParseFailure(parser, "1" + INVALID_SCHEDULE_END_TIME_DESC,
                 MESSAGE_INVALID_TIME); // invalid end time
+
+        assertParseFailure(parser, "1" + INVALID_SCHEDULE_DURATION_DESC,
+                MESSAGE_SCHEDULE_INVALID_DURATION); // invalid duration
+
+        assertParseFailure(parser, "1" + INVALID_SCHEDULE_DURATION_DESC_2,
+                MESSAGE_SCHEDULE_INVALID_DURATION); // invalid duration
+
         assertParseFailure(parser, "1" + INVALID_MODE_DESC, Mode.MESSAGE_CONSTRAINTS); // invalid mode
 
-        // invalid phone followed by valid email
+        // invalid schedule followed by valid mode
         assertParseFailure(parser, "1" + INVALID_SCHEDULE_DATE_DESC + VALID_MODE_DESC,
                 MESSAGE_INVALID_DATE);
 


### PR DESCRIPTION
Fixes #217, #236 

My updates:
- Update `AddScheduleCommandParser` to show `AddScheduleCommand`'s message usage when args are empty
- Change `CANDIDATE_INDEX` to `INDEX`
- Add `SCHEDULE_INDEX` to delete and edit schedule command usage to specify the chosen schedule index in the schedule board
- Add constraints on the duration of the interview with minium of 15 mins and maximum of 4 hours
- Update error message to show the contraints when the user is typing invalid duration

I don't set the constraints on the day of interview since I think it allows more flexibility for the user but can include in the plan enhancements